### PR TITLE
Added stringify name data

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -91,7 +91,7 @@ Browser.prototype.onReceive_ = function (message, rinfo) {
                         self.servTypes.push(answer.data);
                         q.push({
                             type: 'PTR',
-                            name: answer.data
+                            name: ''+answer.data
                         })
                     }
                 })


### PR DESCRIPTION
Sometimes dns-packet throws error

```
!!! { type: 'PTR',
  name: <Buffer 32 4c 4b 44 43 3a 53 48 41 31 2e 36 45 41 36 46 39 30 37 39 34 37 41 35 38 36 30 36 33 35 32 33 37 42 33 37 33 31 42 46 38 34 38 35 46 45 34 44 31 43 ... > }
/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/dns-packet/index.js:18
  var list = n.split('.')
               ^

TypeError: n.split is not a function
    at Object.name.encode (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/dns-packet/index.js:18:16)
    at Object.question.encode (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/dns-packet/index.js:469:8)
    at encodeList (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/dns-packet/index.js:580:9)
    at Object.exports.encode (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/dns-packet/index.js:533:12)
    at Browser.broadcast (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/aloha-sd/lib/browser.js:54:22)
    at Browser.onReceive_ (/home/encobrain/code/js/bitbucket.org/teradek/ttf/node_modules/aloha-sd/lib/browser.js:98:22)
    at emitTwo (events.js:106:13)
    at Socket.emit (events.js:194:7)
    at UDP.onMessage [as onmessage] (dgram.js:544:8)
```